### PR TITLE
Fix invalid closing tags in navigation menu

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -29,8 +29,9 @@ const pathname = new URL(Astro.request.url).pathname;
           target="_blank"
           rel="noopener noreferrer"
           class="text-base lg:text-lg font-medium hover:text-white transition-colors"
-          >Catastro</a
         >
+          Catastro
+        </a>
       </li>
       <li>
         <a
@@ -38,8 +39,9 @@ const pathname = new URL(Astro.request.url).pathname;
           target="_blank"
           rel="noopener noreferrer"
           class="text-base lg:text-lg font-medium hover:text-white transition-colors"
-          >Rentas</a
         >
+          Rentas
+        </a>
       </li>
     </ul>
   </div>
@@ -125,8 +127,9 @@ const pathname = new URL(Astro.request.url).pathname;
             target="_blank"
             rel="noopener noreferrer"
             class="text-base lg:text-lg font-medium hover:text-white transition-colors"
-            >Catastro</a
           >
+            Catastro
+          </a>
         </li>
         <li>
           <a
@@ -134,8 +137,9 @@ const pathname = new URL(Astro.request.url).pathname;
             target="_blank"
             rel="noopener noreferrer"
             class="text-base lg:text-lg font-medium hover:text-white transition-colors"
-            }>Rentas</a
           >
+            Rentas
+          </a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- fix markup for external links in `Navigation.astro`

## Testing
- `npx tsc --noEmit` *(fails: cannot find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68436b81fa708326b290f5c954e69f12